### PR TITLE
Remove unnecessary navigation bar width  modifier

### DIFF
--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -99,15 +99,6 @@ public struct NavigationBar: BlockElement {
         return copy
     }
     
-    /// Adjust the width of the navigation bar
-    /// - Parameter columnWidth: How many columns this should occupy when placed in a section.
-    /// - Returns: A new `NavigationBar` instance with the updated column width
-    public func navigationBarColumnWidth(_ columnWidth: ColumnWidth) -> Self {
-        var copy = self
-        copy.columnWidth = columnWidth
-        return copy
-    }
-
     func theme(for style: NavigationBarStyle) -> String? {
         switch style {
         case .default: nil

--- a/Tests/IgniteTests/Elements/NavigationBar.swift
+++ b/Tests/IgniteTests/Elements/NavigationBar.swift
@@ -19,7 +19,7 @@ final class NavigationBarTests: ElementTest {
     }
     
     func test_columnWidthValueSet() {
-        let element = NavigationBar().navigationBarColumnWidth(.count(10))
+        let element = NavigationBar().width(10)
         let output = element.render(context: publishingContext)
         
         XCTAssertTrue(output.contains("container-fluid col-md-10"))


### PR DESCRIPTION
Removes unnecessary navigation bar width modifier in favor of the default implimentation of `width()`.